### PR TITLE
Remove ReadLeaf and WriteLeaf

### DIFF
--- a/editor/src/ast/ast.rs
+++ b/editor/src/ast/ast.rs
@@ -75,7 +75,9 @@ impl<'l> Ast<'l> {
         F: FnOnce(&mut Text) -> T,
     {
         assert_eq!(self.arity(), Some(Arity::Text));
-        self.tree.child_leaf_mut(f)
+        let out = self.tree.child_leaf_mut(f);
+        self.update();
+        out
     }
 
     /// Get the language of this node's syntactic construct.

--- a/editor/src/ast/ast.rs
+++ b/editor/src/ast/ast.rs
@@ -295,6 +295,18 @@ impl<'a, 'l> AstKind<'a, 'l> {
             _ => panic!("expected AstKind::Text"),
         }
     }
+    pub fn unwrap_fixed(self) -> FixedAst<'a, 'l> {
+        match self {
+            AstKind::Fixed(ast) => ast,
+            _ => panic!("expected AstKind::Fixed"),
+        }
+    }
+    pub fn unwrap_flexible(self) -> FlexibleAst<'a, 'l> {
+        match self {
+            AstKind::Flexible(ast) => ast,
+            _ => panic!("expected AstKind::Flexible"),
+        }
+    }
 }
 
 pub struct TextAst<'a, 'l> {

--- a/editor/src/ast/ast.rs
+++ b/editor/src/ast/ast.rs
@@ -265,10 +265,10 @@ impl<'l> Ast<'l> {
     /// Panics if this is a leaf node.
     fn update(&mut self) {
         let bookmark = self.bookmark();
-        self.tree.data_mut().bounds = Bounds::compute(&self.borrow());
+        self.tree.data_mut().bounds = Bounds::compute(&self.ast_ref());
         while !self.is_at_root() {
             self.goto_parent();
-            self.tree.data_mut().bounds = Bounds::compute(&self.borrow());
+            self.tree.data_mut().bounds = Bounds::compute(&self.ast_ref());
         }
         self.goto_bookmark(bookmark);
     }

--- a/editor/src/ast/ast.rs
+++ b/editor/src/ast/ast.rs
@@ -52,7 +52,7 @@ impl<'l> Ast<'l> {
         Some(self.tree.data().construct.arity.clone())
     }
 
-    /// Calls the closure, giving it read-access to this node's text.
+    /// Call the closure, giving it read-access to this node's text.
     ///
     /// # Panics
     ///
@@ -65,7 +65,7 @@ impl<'l> Ast<'l> {
         self.tree.child_leaf(f)
     }
 
-    /// Calls the closure, giving it write-access to this node's text.
+    /// Call the closure, giving it write-access to this node's text.
     ///
     /// # Panics
     ///
@@ -95,11 +95,12 @@ impl<'l> Ast<'l> {
         &self.tree.data().notation
     }
 
-    /// Replace a node's `i`th child. Returns the replaced child.
+    /// Replace this node's `i`th child. Return the replaced child.
     ///
     /// # Panics
     ///
-    /// Panics if this node's arity is not `Fixed` or `Flexible`.
+    /// Panics if this node's arity is not `Fixed` or `Flexible`, or if `i` is
+    /// out of bounds.
     fn replace_child(&mut self, i: usize, tree: Ast<'l>) -> Ast<'l> {
         if let Some(arity) = self.arity() {
             if !arity.is_fixed() && !arity.is_flexible() {
@@ -223,7 +224,7 @@ impl<'l> Ast<'l> {
         self.tree.goto_root()
     }
 
-    /// Go to this tree's i'th child. For nodes of `Mixed` arity, `i` counts
+    /// Go to this node's i'th child. For nodes of `Mixed` arity, `i` counts
     /// both tree and text children.
     ///
     /// # Panics
@@ -309,11 +310,13 @@ impl<'a, 'l> AstKind<'a, 'l> {
     }
 }
 
+/// A wrapper around an `Ast` with `Text` arity.
 pub struct TextAst<'a, 'l> {
     ast: &'a mut Ast<'l>,
 }
 
 impl<'a, 'l> TextAst<'a, 'l> {
+    /// Call the closure, giving it read-access to this node's text.
     pub fn text<F, T>(&self, f: F) -> T
     where
         F: FnOnce(&Text) -> T,
@@ -321,6 +324,7 @@ impl<'a, 'l> TextAst<'a, 'l> {
         self.ast.text(f)
     }
 
+    /// Call the closure, giving it write-access to this node's text.
     pub fn text_mut<F, T>(&mut self, f: F) -> T
     where
         F: FnOnce(&mut Text) -> T,
@@ -329,45 +333,80 @@ impl<'a, 'l> TextAst<'a, 'l> {
     }
 }
 
+/// A wrapper around an `Ast` with `Fixed` arity.
 pub struct FixedAst<'a, 'l> {
     ast: &'a mut Ast<'l>,
 }
 
 impl<'a, 'l> FixedAst<'a, 'l> {
+    /// Return the number of children this node has. For a Fixed node, this is
+    /// the same as its arity.
     pub fn num_children(&self) -> usize {
         self.ast.num_children()
     }
 
+    /// Go to this node's i'th child.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `i` is out of bounds.
     pub fn goto_child(&mut self, i: usize) {
         self.ast.goto_child(i)
     }
 
+    /// Replace this node's `i`th child. Return the replaced child.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `i` is out of bounds.
     pub fn replace_child(&mut self, i: usize, tree: Ast<'l>) -> Ast<'l> {
         self.ast.replace_child(i, tree)
     }
 }
 
+/// A wrapper around an `Ast` with `Flexible` arity.
 pub struct FlexibleAst<'a, 'l> {
     ast: &'a mut Ast<'l>,
 }
 
 impl<'a, 'l> FlexibleAst<'a, 'l> {
+    /// Return the number of children this node currently has.
     pub fn num_children(&self) -> usize {
         self.ast.num_children()
     }
 
+    /// Go to this node's i'th child.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `i` is out of bounds.
     pub fn goto_child(&mut self, i: usize) {
         self.ast.goto_child(i)
     }
 
+    /// Replace this node's `i`th child. Return the replaced child.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `i` is out of bounds.
     pub fn replace_child(&mut self, i: usize, tree: Ast<'l>) -> Ast<'l> {
         self.ast.replace_child(i, tree)
     }
 
+    /// Insert `tree` as the `i`th child of this node.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `i` is out of bounds.
     pub fn insert_child(&mut self, i: usize, tree: Ast<'l>) {
         self.ast.insert_child(i, tree)
     }
 
+    /// Remove and return the `i`th child of this node.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `i` is out of bounds.
     pub fn remove_child(&mut self, i: usize) -> Ast<'l> {
         self.ast.remove_child(i)
     }

--- a/editor/src/ast/ast_ref.rs
+++ b/editor/src/ast/ast_ref.rs
@@ -6,7 +6,7 @@ use crate::ast::ast::{Ast, Node};
 use crate::text::Text;
 
 impl<'f, 'l> Ast<'l> {
-    pub fn borrow(&'f self) -> AstRef<'f, 'l> {
+    pub fn ast_ref(&'f self) -> AstRef<'f, 'l> {
         AstRef {
             tree_ref: self.tree.borrow(),
         }

--- a/editor/src/doc.rs
+++ b/editor/src/doc.rs
@@ -114,7 +114,7 @@ impl<'l> Doc<'l> {
     }
 
     pub fn ast_ref<'f>(&'f self) -> AstRef<'f, 'l> {
-        self.ast.borrow()
+        self.ast.ast_ref()
     }
 
     pub fn in_tree_mode(&self) -> bool {

--- a/editor/src/doc.rs
+++ b/editor/src/doc.rs
@@ -322,7 +322,7 @@ impl<'l> Doc<'l> {
                 AstKind::Text(mut text) => {
                     // Enter text mode
                     self.mode = Mode::Text(i);
-                    text.text_mut().as_mut().activate();
+                    text.text_mut(|t| t.activate());
                     vec![TextNavCmd::TreeMode.into()]
                 }
                 AstKind::Fixed(mut ast) => {
@@ -352,23 +352,23 @@ impl<'l> Doc<'l> {
         let char_index = self.mode.unwrap_text_pos();
         let undos = match cmd {
             TextCmd::InsertChar(character) => {
-                ast.text_mut().as_mut().insert(char_index, character);
+                ast.text_mut(|t| t.insert(char_index, character));
                 self.mode = Mode::Text(char_index + 1);
                 vec![TextCmd::DeleteCharBackward.into()]
             }
             TextCmd::DeleteCharForward => {
-                let text_len = ast.text().as_text_ref().num_chars();
+                let text_len = ast.text(|t| t.num_chars());
                 if char_index == text_len {
                     return Err(());
                 }
-                let c = ast.text_mut().as_mut().delete(char_index);
+                let c = ast.text_mut(|t| t.delete(char_index));
                 vec![TextCmd::InsertChar(c).into()]
             }
             TextCmd::DeleteCharBackward => {
                 if char_index == 0 {
                     return Err(());
                 }
-                let c = ast.text_mut().as_mut().delete(char_index - 1);
+                let c = ast.text_mut(|t| t.delete(char_index - 1));
                 self.mode = Mode::Text(char_index - 1);
                 vec![TextCmd::InsertChar(c).into()]
             }
@@ -391,7 +391,7 @@ impl<'l> Doc<'l> {
                 vec![TextNavCmd::Right.into()]
             }
             TextNavCmd::Right => {
-                if char_index >= ast.text().as_text_ref().num_chars() {
+                if char_index >= ast.text(|t| t.num_chars()) {
                     return Err(());
                 }
                 self.mode = Mode::Text(char_index + 1);
@@ -399,7 +399,7 @@ impl<'l> Doc<'l> {
             }
             TextNavCmd::TreeMode => {
                 // Exit text mode
-                ast.text_mut().as_mut().inactivate();
+                ast.text_mut(|t| t.inactivate());
                 self.mode = Mode::Tree;
                 vec![TreeNavCmd::Child(char_index).into()]
             }

--- a/editor/src/text.rs
+++ b/editor/src/text.rs
@@ -87,6 +87,18 @@ impl Text {
             _ => panic!("Text::delete - tried to edit inactive text"),
         }
     }
+
+    /// Set the text to the given string, replacing the current contents.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the `Text` is inactive.
+    pub fn set(&mut self, s: String) {
+        match self {
+            Text::Active(active_text) => active_text.set(s),
+            _ => panic!("Text::set - tried to edit inactive text"),
+        }
+    }
 }
 
 impl AsRef<str> for Text {
@@ -110,6 +122,10 @@ impl ActiveText {
 
     fn insert(&mut self, char_index: usize, character: char) {
         self.0.insert(self.byte_index(char_index), character);
+    }
+
+    fn set(&mut self, s: String) {
+        self.0 = s;
     }
 
     fn byte_index(&self, char_index: usize) -> usize {

--- a/editor/tests/test_json_doc.rs
+++ b/editor/tests/test_json_doc.rs
@@ -290,7 +290,7 @@ fn test_json_string() {
         &mut clipboard,
     )
     .unwrap();
-    assert_render(&doc, "\"a\"");
+    assert_render(&doc, "[\"a\"]");
 }
 
 fn assert_render(doc: &Doc, rendered: &str) {


### PR DESCRIPTION
Take closures that can read or write the leaf instead. Same for ReadText and WriteText.

This let us fix the longstanding bug where text bounds were not updated after the text was edited, causing a panic when attempting to render it.