### PR TITLE
Enforce grammar of Ast

### DIFF
--- a/demo/src/error.rs
+++ b/demo/src/error.rs
@@ -1,6 +1,7 @@
 use std::io;
 use termion::event::Key;
 
+use editor::DocError;
 use frontends::terminal;
 use language::{ConstructName, LanguageName};
 use pretty::PaneError;
@@ -19,8 +20,8 @@ pub enum Error {
     },
     ExpectedWord(String),
     EmptyStack,
-    DocExec(String),
     Pane(PaneError<terminal::Error>),
+    DocExec(DocError<'static>),
     Io(io::Error),
     Term(terminal::Error),
 }
@@ -40,5 +41,11 @@ impl From<io::Error> for Error {
 impl From<terminal::Error> for Error {
     fn from(e: terminal::Error) -> Error {
         Error::Term(e)
+    }
+}
+
+impl From<DocError<'static>> for Error {
+    fn from(e: DocError<'static>) -> Error {
+        Error::DocExec(e)
     }
 }

--- a/demo/src/keymap_lang.rs
+++ b/demo/src/keymap_lang.rs
@@ -12,16 +12,11 @@ pub fn make_keymap_lang() -> (Language, NotationSet) {
     let constructs = vec![
         Construct::new("key", "Key", Arity::Text, Some('k')),
         Construct::new("prog", "Value", Arity::Text, Some('p')),
-        Construct::new(
-            "dict",
-            "Dict",
-            Arity::Flexible("Entry".to_string()),
-            Some('d'),
-        ),
+        Construct::new("dict", "Dict", Arity::Flexible("Entry".into()), Some('d')),
         Construct::new(
             "entry",
             "Entry",
-            Arity::Fixed(vec!["Key".to_string(), "Value".to_string()]),
+            Arity::Fixed(vec!["Key".into(), "Value".into()]),
             Some('e'),
         ),
     ];

--- a/demo/src/main.rs
+++ b/demo/src/main.rs
@@ -9,7 +9,7 @@ use editor::{
     TreeCmd, TreeNavCmd,
 };
 use frontends::{Event, Frontend, Terminal};
-use language::{LanguageName, LanguageSet};
+use language::{LanguageName, LanguageSet, Sort};
 use pretty::{Color, ColorTheme, CursorVis, DocLabel, Pane, PaneNotation, PaneSize, Style};
 use utility::GrowOnlyMap;
 
@@ -20,10 +20,10 @@ mod message_lang;
 mod prog;
 
 use error::Error;
-use keymap::Keymap;
+use keymap::{FilteredKmap, KmapFactory};
 use keymap_lang::make_keymap_lang;
 use message_lang::make_message_lang;
-use prog::{Prog, Stack, Word};
+use prog::{KmapSpec, Stack, Word};
 
 lazy_static! {
     pub static ref LANG_SET: LanguageSet = LanguageSet::new();
@@ -49,8 +49,8 @@ struct Ed {
     message_doc: Doc<'static>,
     message_lang_name: LanguageName,
     stack: Stack<'static>,
-    keymaps: HashMap<String, Keymap<'static>>,
-    keymap_stack: Vec<String>,
+    keymaps: HashMap<String, KmapFactory<'static>>,
+    keymap_stack: Vec<KmapSpec>,
     kmap_lang_name: LanguageName,
     key_hints: Doc<'static>,
     cut_stack: Clipboard<'static>,
@@ -79,11 +79,11 @@ impl Ed {
         let msg_doc = new_doc("Messages", &msg_lang_name, &forest);
 
         let mut maps = HashMap::new();
-        maps.insert("tree".to_string(), Keymap::tree());
-        maps.insert("speed_bool".to_string(), Keymap::speed_bool());
+        maps.insert("tree".to_string(), KmapFactory::make_tree_map());
+        maps.insert("speed_bool".to_string(), KmapFactory::make_speed_bool_map());
         maps.insert(
             "node".to_string(),
-            Keymap::node(LANG_SET.get(&json_lang_name).unwrap()),
+            KmapFactory::make_node_map(LANG_SET.get(&json_lang_name).unwrap()),
         );
 
         let mut ed = Ed {
@@ -104,6 +104,7 @@ impl Ed {
 
         // Set initial keymap
         ed.push(Word::MapName("tree".into()))?;
+        ed.push(Word::AnySort)?;
         ed.push(Word::PushMap)?;
 
         // Add an empty list to the document
@@ -229,11 +230,13 @@ impl Ed {
         Ok(())
     }
 
-    fn active_keymap(&self) -> Result<&Keymap<'static>, Error> {
-        let name = self.keymap_stack.last().ok_or(Error::NoKeymap)?;
-        self.keymaps
-            .get(name)
-            .ok_or_else(|| Error::UnknownKeymap(name.to_owned()))
+    fn active_keymap(&self) -> Result<FilteredKmap<'static>, Error> {
+        let kmap = self.keymap_stack.last().ok_or(Error::NoKeymap)?;
+        Ok(self
+            .keymaps
+            .get(&kmap.name)
+            .ok_or_else(|| Error::UnknownKeymap(kmap.name.to_owned()))?
+            .filter(self.doc.ast_ref(), &kmap.required_sort))
     }
 
     fn update_key_hints(&mut self) -> Result<(), Error> {
@@ -277,21 +280,19 @@ impl Ed {
             .replace_child(0, dict_node)
             .unwrap();
 
-        let keymap_name = self.keymap_stack.join("→");
-        self.key_hints = Doc::new(&keymap_name, root_node);
+        let mut kmap_name = String::new();
+        for (i, spec) in self.keymap_stack.iter().enumerate() {
+            if i != 0 {
+                kmap_name += "→";
+            }
+            kmap_name += &spec.name;
+        }
+        self.key_hints = Doc::new(&kmap_name, root_node);
         Ok(())
     }
 
-    fn lookup_key(&self, key: Key) -> Result<Prog<'static>, Error> {
-        self.active_keymap()?
-            .0
-            .get(&key)
-            .cloned()
-            .ok_or(Error::UnknownKey(key))
-    }
-
     fn handle_key(&mut self, key: Key) -> Result<(), Error> {
-        let prog = self.lookup_key(key)?;
+        let prog = self.active_keymap()?.lookup(key)?;
         for word in prog.words {
             self.push(word)?;
         }
@@ -317,6 +318,7 @@ impl Ed {
             Word::Tree(..) => self.stack.push(word),
             Word::Usize(..) => self.stack.push(word),
             Word::MapName(..) => self.stack.push(word),
+            Word::Sort(..) => self.stack.push(word),
             Word::LangConstruct(..) => self.stack.push(word),
             Word::Message(..) => self.stack.push(word),
             Word::Char(..) => self.stack.push(word),
@@ -341,13 +343,42 @@ impl Ed {
                 self.push(Word::Tree(node))?;
             }
             Word::PushMap => {
+                let sort = self.stack.pop_sort()?;
                 let name = self.stack.pop_map_name()?;
-                self.keymap_stack.push(name);
+                self.keymap_stack.push(KmapSpec {
+                    name,
+                    required_sort: sort,
+                });
                 self.update_key_hints()?;
             }
             Word::PopMap => {
                 self.keymap_stack.pop();
                 self.update_key_hints()?;
+            }
+            Word::ChildSort => {
+                let sort = self.doc.ast_ref().arity().uniform_child_sort().to_owned();
+                self.stack.push(Word::Sort(sort));
+            }
+            Word::SelfSort => {
+                let (parent, index) = self
+                    .doc
+                    .ast_ref()
+                    .parent()
+                    .expect("you shouldn't be at the root!");
+                let sort = parent.arity().child_sort(index).to_owned();
+                self.stack.push(Word::Sort(sort));
+            }
+            Word::SiblingSort => {
+                let (parent, _) = self
+                    .doc
+                    .ast_ref()
+                    .parent()
+                    .expect("you shouldn't be at the root!");
+                let sort = parent.arity().uniform_child_sort().to_owned();
+                self.stack.push(Word::Sort(sort));
+            }
+            Word::AnySort => {
+                self.stack.push(Word::Sort(Sort::any()));
             }
             Word::Remove => self.exec(TreeCmd::Remove)?,
             Word::InsertChar => {
@@ -397,7 +428,9 @@ impl Ed {
     where
         T: Debug + Into<CommandGroup<'static>>,
     {
-        Ok(self.doc.execute(cmd.into(), &mut self.cut_stack)?)
+        self.doc.execute(cmd.into(), &mut self.cut_stack)?;
+        self.update_key_hints()?;
+        Ok(())
     }
 
     fn node_by_name(

--- a/demo/src/main.rs
+++ b/demo/src/main.rs
@@ -139,10 +139,15 @@ impl Ed {
             list_node
                 .inner()
                 .unwrap_flexible()
-                .insert_child(i, msg_node);
+                .insert_child(i, msg_node)
+                .unwrap();
         }
         let mut root_node = self.node_by_name("root", &self.message_lang_name)?;
-        root_node.inner().unwrap_fixed().replace_child(0, list_node);
+        root_node
+            .inner()
+            .unwrap_fixed()
+            .replace_child(0, list_node)
+            .unwrap();
         self.message_doc = Doc::new(self.message_doc.name(), root_node);
         Ok(())
     }
@@ -250,16 +255,27 @@ impl Ed {
             });
 
             let mut entry_node = self.node_by_name("entry", &self.kmap_lang_name)?;
-            entry_node.inner().unwrap_fixed().replace_child(0, key_node);
             entry_node
                 .inner()
                 .unwrap_fixed()
-                .replace_child(1, prog_node);
+                .replace_child(0, key_node)
+                .unwrap();
+            entry_node
+                .inner()
+                .unwrap_fixed()
+                .replace_child(1, prog_node)
+                .unwrap();
             let mut inner_dict = dict_node.inner().unwrap_flexible();
-            inner_dict.insert_child(inner_dict.num_children(), entry_node);
+            inner_dict
+                .insert_child(inner_dict.num_children(), entry_node)
+                .unwrap();
         }
         let mut root_node = self.node_by_name("root", &self.kmap_lang_name)?;
-        root_node.inner().unwrap_fixed().replace_child(0, dict_node);
+        root_node
+            .inner()
+            .unwrap_fixed()
+            .replace_child(0, dict_node)
+            .unwrap();
 
         let keymap_name = self.keymap_stack.join("→");
         self.key_hints = Doc::new(&keymap_name, root_node);
@@ -381,10 +397,7 @@ impl Ed {
     where
         T: Debug + Into<CommandGroup<'static>>,
     {
-        let name = format!("{:?}", cmd);
-        self.doc
-            .execute(cmd.into(), &mut self.cut_stack)
-            .map_err(|_| Error::DocExec(name))
+        Ok(self.doc.execute(cmd.into(), &mut self.cut_stack)?)
     }
 
     fn node_by_name(
@@ -417,7 +430,11 @@ impl Ed {
             t.inactivate();
         });
         let mut root_node = self.node_by_name("root", &self.message_lang_name)?;
-        root_node.inner().unwrap_fixed().replace_child(0, text_node);
+        root_node
+            .inner()
+            .unwrap_fixed()
+            .replace_child(0, text_node)
+            .unwrap();
         Ok(root_node)
     }
 }

--- a/demo/src/message_lang.rs
+++ b/demo/src/message_lang.rs
@@ -9,7 +9,7 @@ pub fn make_message_lang() -> (Language, NotationSet) {
     ];
     let constructs = vec![
         Construct::new("message", "Message", Arity::Text, None),
-        Construct::new("list", "List", Arity::Flexible("Message".to_string()), None),
+        Construct::new("list", "List", Arity::Flexible("Message".into()), None),
     ];
     // TODO: some of this boilerplate should get abstracted out
     let mut lang = Language::new("message");

--- a/demo/src/prog.rs
+++ b/demo/src/prog.rs
@@ -1,6 +1,6 @@
 use editor::Ast;
 
-use language::{ConstructName, LanguageName};
+use language::{ConstructName, LanguageName, Sort};
 
 use crate::error::Error;
 
@@ -12,6 +12,12 @@ pub struct Prog<'l> {
 
 pub struct Stack<'l>(Vec<Word<'l>>);
 
+#[derive(Clone, Debug)]
+pub struct KmapSpec {
+    pub name: String,
+    pub required_sort: Sort,
+}
+
 #[allow(dead_code)]
 #[derive(Clone, Debug)]
 pub enum Word<'l> {
@@ -20,6 +26,7 @@ pub enum Word<'l> {
     Usize(usize),
     Char(char),
     MapName(String),
+    Sort(Sort),
     LangConstruct(LanguageName, ConstructName),
     Message(String),
     Quote(Box<Word<'l>>),
@@ -32,6 +39,10 @@ pub enum Word<'l> {
     // editor-specific:
     PushMap,
     PopMap,
+    SelfSort,
+    ChildSort,
+    SiblingSort,
+    AnySort,
     NodeByName,
     Echo,
 
@@ -115,6 +126,14 @@ impl<'l> Stack<'l> {
             Ok(s)
         } else {
             Err(Error::ExpectedWord("MapName".into()))
+        }
+    }
+
+    pub fn pop_sort(&mut self) -> Result<Sort, Error> {
+        if let Word::Sort(s) = self.pop()? {
+            Ok(s)
+        } else {
+            Err(Error::ExpectedWord("Sort".into()))
         }
     }
 

--- a/editor/src/ast/ast.rs
+++ b/editor/src/ast/ast.rs
@@ -95,7 +95,9 @@ impl<'l> Ast<'l> {
         &self.tree.data().notation
     }
 
-    /// Replace this node's `i`th child. Return the replaced child.
+    /// Replace this node's `i`th child. Return the replaced child. If `tree`
+    /// cannot be inserted because it has the wrong Sort, return it as
+    /// `Err(tree)`.
     ///
     /// # Panics
     ///

--- a/editor/src/doc.rs
+++ b/editor/src/doc.rs
@@ -505,10 +505,16 @@ impl<'l> Doc<'l> {
                 let result = flexible
                     .insert_child(insertion_index, new_ast)
                     .map_err(|rejected_ast| DocError::WrongSort(rejected_ast));
-                // Go back to the node we started on, before possibly
-                // early-returning an error.
-                flexible.goto_child(insertion_index);
-                result?;
+
+                if let Err(err) = result {
+                    // Go back to the node we started on!
+                    flexible.goto_child(i);
+                    return Err(err);
+                } else {
+                    // Go to the node we successfully inserted.
+                    flexible.goto_child(insertion_index);
+                }
+
                 if before && i != 0 {
                     Ok(vec![TreeNavCmd::Right.into(), TreeCmd::Remove.into()])
                 } else {

--- a/editor/src/doc.rs
+++ b/editor/src/doc.rs
@@ -4,6 +4,19 @@ use crate::ast::{Ast, AstKind, AstRef};
 use crate::command::{Command, CommandGroup, EditorCmd, TextCmd, TextNavCmd, TreeCmd, TreeNavCmd};
 
 #[derive(Debug)]
+pub enum DocError<'l> {
+    NotInTextMode,
+    NotInTreeMode,
+    NothingToUndo,
+    NothingToRedo,
+    WrongSort(Ast<'l>),
+    CannotPaste,
+    CannotMove,
+    CannotRemoveNode,
+    CannotDeleteChar,
+}
+
+#[derive(Debug)]
 pub struct UndoGroup<'l> {
     contains_edit: bool,
     commands: Vec<Command<'l>>,
@@ -84,10 +97,10 @@ impl Mode {
         }
     }
 
-    fn unwrap_text_pos(&self) -> usize {
+    fn text_pos(&self) -> Option<usize> {
         match self {
-            Mode::Text(pos) => *pos,
-            _ => panic!("tried to execute text command in tree mode"),
+            Mode::Text(pos) => Some(*pos),
+            _ => None,
         }
     }
 }
@@ -129,7 +142,7 @@ impl<'l> Doc<'l> {
         mem::replace(&mut self.recent, UndoGroup::new())
     }
 
-    fn undo(&mut self, clipboard: &mut Clipboard<'l>) -> Result<(), ()> {
+    fn undo(&mut self, clipboard: &mut Clipboard<'l>) -> Result<(), DocError<'l>> {
         assert!(self.recent.commands.is_empty());
         assert!(!self.recent.contains_edit);
 
@@ -153,11 +166,11 @@ impl<'l> Doc<'l> {
             }
             Ok(())
         } else {
-            Err(()) // There are no edits on the undo stack
+            Err(DocError::NothingToUndo) // There are no edits on the undo stack
         }
     }
 
-    fn redo(&mut self, clipboard: &mut Clipboard<'l>) -> Result<(), ()> {
+    fn redo(&mut self, clipboard: &mut Clipboard<'l>) -> Result<(), DocError<'l>> {
         assert!(self.recent.commands.is_empty());
         assert!(!self.recent.contains_edit);
 
@@ -181,7 +194,7 @@ impl<'l> Doc<'l> {
             }
             Ok(())
         } else {
-            Err(()) // There are no edits on the redo stack
+            Err(DocError::NothingToRedo) // There are no edits on the redo stack
         }
     }
 
@@ -189,7 +202,7 @@ impl<'l> Doc<'l> {
         &mut self,
         cmds: CommandGroup<'l>,
         clipboard: &mut Clipboard<'l>,
-    ) -> Result<(), ()> {
+    ) -> Result<(), DocError<'l>> {
         match cmds {
             CommandGroup::Undo => self.undo(clipboard),
             CommandGroup::Redo => self.redo(clipboard),
@@ -205,7 +218,11 @@ impl<'l> Doc<'l> {
         }
     }
 
-    fn execute_group<I>(&mut self, cmds: I, clipboard: &mut Clipboard<'l>) -> Result<(), ()>
+    fn execute_group<I>(
+        &mut self,
+        cmds: I,
+        clipboard: &mut Clipboard<'l>,
+    ) -> Result<(), DocError<'l>>
     where
         I: IntoIterator<Item = Command<'l>>,
     {
@@ -226,9 +243,9 @@ impl<'l> Doc<'l> {
         &mut self,
         cmd: EditorCmd,
         clipboard: &mut Clipboard<'l>,
-    ) -> Result<UndoGroup<'l>, ()> {
+    ) -> Result<UndoGroup<'l>, DocError<'l>> {
         if !self.mode.is_tree_mode() {
-            panic!("tried to execute editor command in text mode")
+            return Err(DocError::NotInTreeMode);
         }
         match cmd {
             EditorCmd::Cut => {
@@ -280,27 +297,26 @@ impl<'l> Doc<'l> {
         }
     }
 
-    fn execute_tree(&mut self, cmd: TreeCmd<'l>) -> Result<UndoGroup<'l>, ()> {
+    fn execute_tree(&mut self, cmd: TreeCmd<'l>) -> Result<UndoGroup<'l>, DocError<'l>> {
         if !self.mode.is_tree_mode() {
-            panic!("tried to execute tree command in text mode")
+            return Err(DocError::NotInTreeMode);
         }
         let undos = match cmd {
             TreeCmd::Replace(new_ast) => {
-                let i = self.ast.goto_parent();
+                let i = self.ast.goto_parent(); // child index
                 match self.ast.inner() {
                     AstKind::Fixed(mut fixed) => {
-                        // TODO handle error better
-                        let old_ast = fixed.replace_child(i, new_ast).expect("failed to replace");
+                        let result = fixed.replace_child(i, new_ast);
                         fixed.goto_child(i);
+                        let old_ast =
+                            result.map_err(|rejected_ast| DocError::WrongSort(rejected_ast))?;
                         vec![TreeCmd::Replace(old_ast).into()]
                     }
                     AstKind::Flexible(mut flexible) => {
-                        // TODO handle error better
-                        let old_ast = flexible
-                            .replace_child(i, new_ast)
-                            .expect("failed to replace");
-
+                        let result = flexible.replace_child(i, new_ast);
                         flexible.goto_child(i);
+                        let old_ast =
+                            result.map_err(|rejected_ast| DocError::WrongSort(rejected_ast))?;
                         vec![TreeCmd::Replace(old_ast).into()]
                     }
                     _ => panic!("how can a parent not be fixed or flexible?"),
@@ -321,17 +337,15 @@ impl<'l> Doc<'l> {
         })
     }
 
-    fn execute_tree_nav(&mut self, cmd: TreeNavCmd) -> Result<UndoGroup<'l>, ()> {
+    fn execute_tree_nav(&mut self, cmd: TreeNavCmd) -> Result<UndoGroup<'l>, DocError<'l>> {
         if !self.mode.is_tree_mode() {
-            // TODO: once there's scripting or user-defined keybindings,
-            // this needs to be a gentler error.
-            panic!("tried to execute tree navigation command in text mode")
+            return Err(DocError::NotInTreeMode);
         }
         let undos = match cmd {
             TreeNavCmd::Left => {
                 let i = self.ast.index();
                 if i == 0 {
-                    return Err(());
+                    return Err(DocError::CannotMove);
                 }
                 self.ast.goto_sibling(i - 1);
                 vec![TreeNavCmd::Right.into()]
@@ -340,7 +354,7 @@ impl<'l> Doc<'l> {
                 let i = self.ast.index();
                 let n = self.ast.num_siblings();
                 if i + 1 >= n {
-                    return Err(());
+                    return Err(DocError::CannotMove);
                 }
                 self.ast.goto_sibling(i + 1);
                 vec![TreeNavCmd::Left.into()]
@@ -348,7 +362,7 @@ impl<'l> Doc<'l> {
             TreeNavCmd::Parent => {
                 if self.ast.is_parent_at_root() {
                     // User should never be able to select the root node
-                    return Err(());
+                    return Err(DocError::CannotMove);
                 }
                 let i = self.ast.goto_parent();
                 vec![TreeNavCmd::Child(i).into()]
@@ -362,14 +376,14 @@ impl<'l> Doc<'l> {
                 }
                 AstKind::Fixed(mut ast) => {
                     if i >= ast.num_children() {
-                        return Err(());
+                        return Err(DocError::CannotMove);
                     }
                     ast.goto_child(i);
                     vec![TreeNavCmd::Parent.into()]
                 }
                 AstKind::Flexible(mut ast) => {
                     if i >= ast.num_children() {
-                        return Err(());
+                        return Err(DocError::CannotMove);
                     }
                     ast.goto_child(i);
                     vec![TreeNavCmd::Parent.into()]
@@ -382,9 +396,9 @@ impl<'l> Doc<'l> {
         })
     }
 
-    fn execute_text(&mut self, cmd: TextCmd) -> Result<UndoGroup<'l>, ()> {
+    fn execute_text(&mut self, cmd: TextCmd) -> Result<UndoGroup<'l>, DocError<'l>> {
+        let char_index = self.mode.text_pos().ok_or(DocError::NotInTextMode)?;
         let mut ast = self.ast.inner().unwrap_text();
-        let char_index = self.mode.unwrap_text_pos();
         let undos = match cmd {
             TextCmd::InsertChar(character) => {
                 ast.text_mut(|t| t.insert(char_index, character));
@@ -394,14 +408,14 @@ impl<'l> Doc<'l> {
             TextCmd::DeleteCharForward => {
                 let text_len = ast.text(|t| t.num_chars());
                 if char_index == text_len {
-                    return Err(());
+                    return Err(DocError::CannotDeleteChar);
                 }
                 let c = ast.text_mut(|t| t.delete(char_index));
                 vec![TextCmd::InsertChar(c).into()]
             }
             TextCmd::DeleteCharBackward => {
                 if char_index == 0 {
-                    return Err(());
+                    return Err(DocError::CannotDeleteChar);
                 }
                 let c = ast.text_mut(|t| t.delete(char_index - 1));
                 self.mode = Mode::Text(char_index - 1);
@@ -414,20 +428,20 @@ impl<'l> Doc<'l> {
         })
     }
 
-    fn execute_text_nav(&mut self, cmd: TextNavCmd) -> Result<UndoGroup<'l>, ()> {
-        let char_index = self.mode.unwrap_text_pos();
+    fn execute_text_nav(&mut self, cmd: TextNavCmd) -> Result<UndoGroup<'l>, DocError<'l>> {
+        let char_index = self.mode.text_pos().ok_or(DocError::NotInTextMode)?;
         let mut ast = self.ast.inner().unwrap_text();
         let undos = match cmd {
             TextNavCmd::Left => {
                 if char_index == 0 {
-                    return Err(());
+                    return Err(DocError::CannotMove);
                 }
                 self.mode = Mode::Text(char_index - 1);
                 vec![TextNavCmd::Right.into()]
             }
             TextNavCmd::Right => {
                 if char_index >= ast.text(|t| t.num_chars()) {
-                    return Err(());
+                    return Err(DocError::CannotMove);
                 }
                 self.mode = Mode::Text(char_index + 1);
                 vec![TextNavCmd::Left.into()]
@@ -453,15 +467,14 @@ impl<'l> Doc<'l> {
         &mut self,
         at_start: bool,
         new_ast: Ast<'l>,
-    ) -> Result<Vec<Command<'l>>, ()> {
+    ) -> Result<Vec<Command<'l>>, DocError<'l>> {
         match self.ast.inner() {
             AstKind::Flexible(mut flexible) => {
                 let original_num_children = flexible.num_children();
                 let index = if at_start { 0 } else { original_num_children };
-                // TODO handle error better
                 flexible
                     .insert_child(index, new_ast)
-                    .expect("failed to insert");
+                    .map_err(|rejected_ast| DocError::WrongSort(rejected_ast))?;
                 flexible.goto_child(index);
                 let mut undo = Vec::new();
                 if original_num_children != 0 {
@@ -473,7 +486,7 @@ impl<'l> Doc<'l> {
                 undo.push(TreeCmd::Remove.into());
                 Ok(undo)
             }
-            _ => Err(()),
+            _ => Err(DocError::WrongSort(new_ast)),
         }
     }
 
@@ -481,20 +494,27 @@ impl<'l> Doc<'l> {
     /// this node. Otherwise, insert it immediately to the right. If the
     /// insertion is successful, return the list of commands needed to undo it.
     /// Otherwise, return `Err`.
-    fn insert_sibling(&mut self, before: bool, new_ast: Ast<'l>) -> Result<Vec<Command<'l>>, ()> {
+    fn insert_sibling(
+        &mut self,
+        before: bool,
+        new_ast: Ast<'l>,
+    ) -> Result<Vec<Command<'l>>, DocError<'l>> {
         let i = self.ast.goto_parent();
         let insertion_index = if before { i } else { i + 1 };
         match self.ast.inner() {
             AstKind::Fixed(mut fixed) => {
                 // Oops, go back, we can't insert something into a fixed node.
                 fixed.goto_child(i);
-                Err(())
+                Err(DocError::WrongSort(new_ast))
             }
             AstKind::Flexible(mut flexible) => {
-                flexible
+                let result = flexible
                     .insert_child(insertion_index, new_ast)
-                    .expect("failed to insert");
+                    .map_err(|rejected_ast| DocError::WrongSort(rejected_ast));
+                // Go back to the node we started on, before possibly
+                // early-returning an error.
                 flexible.goto_child(insertion_index);
+                result?;
                 if before && i != 0 {
                     Ok(vec![TreeNavCmd::Right.into(), TreeCmd::Remove.into()])
                 } else {
@@ -509,13 +529,16 @@ impl<'l> Doc<'l> {
     /// selected Ast, return the original Ast, and return Undo commands
     /// containing a _copy_ of the Ast. Otherwise, return None and use the
     /// original Ast in the Undo commands.
-    fn remove(&mut self, return_original: bool) -> Result<(Vec<Command<'l>>, Option<Ast<'l>>), ()> {
+    fn remove(
+        &mut self,
+        return_original: bool,
+    ) -> Result<(Vec<Command<'l>>, Option<Ast<'l>>), DocError<'l>> {
         let i = self.ast.goto_parent();
         match self.ast.inner() {
             AstKind::Fixed(mut fixed) => {
                 // Oops, go back, we can't delete something from a fixed node.
                 fixed.goto_child(i);
-                Err(())
+                Err(DocError::CannotRemoveNode)
             }
             AstKind::Flexible(mut flexible) => {
                 let old_ast = flexible.remove_child(i);

--- a/editor/src/doc.rs
+++ b/editor/src/doc.rs
@@ -289,12 +289,17 @@ impl<'l> Doc<'l> {
                 let i = self.ast.goto_parent();
                 match self.ast.inner() {
                     AstKind::Fixed(mut fixed) => {
-                        let old_ast = fixed.replace_child(i, new_ast);
+                        // TODO handle error better
+                        let old_ast = fixed.replace_child(i, new_ast).expect("failed to replace");
                         fixed.goto_child(i);
                         vec![TreeCmd::Replace(old_ast).into()]
                     }
                     AstKind::Flexible(mut flexible) => {
-                        let old_ast = flexible.replace_child(i, new_ast);
+                        // TODO handle error better
+                        let old_ast = flexible
+                            .replace_child(i, new_ast)
+                            .expect("failed to replace");
+
                         flexible.goto_child(i);
                         vec![TreeCmd::Replace(old_ast).into()]
                     }
@@ -453,7 +458,10 @@ impl<'l> Doc<'l> {
             AstKind::Flexible(mut flexible) => {
                 let original_num_children = flexible.num_children();
                 let index = if at_start { 0 } else { original_num_children };
-                flexible.insert_child(index, new_ast);
+                // TODO handle error better
+                flexible
+                    .insert_child(index, new_ast)
+                    .expect("failed to insert");
                 flexible.goto_child(index);
                 let mut undo = Vec::new();
                 if original_num_children != 0 {
@@ -483,7 +491,9 @@ impl<'l> Doc<'l> {
                 Err(())
             }
             AstKind::Flexible(mut flexible) => {
-                flexible.insert_child(insertion_index, new_ast);
+                flexible
+                    .insert_child(insertion_index, new_ast)
+                    .expect("failed to insert");
                 flexible.goto_child(insertion_index);
                 if before && i != 0 {
                     Ok(vec![TreeNavCmd::Right.into(), TreeCmd::Remove.into()])

--- a/editor/src/lib.rs
+++ b/editor/src/lib.rs
@@ -11,6 +11,6 @@ pub use self::ast::{Ast, AstForest, AstRef};
 pub use self::command::{
     Command, CommandGroup, EditorCmd, TextCmd, TextNavCmd, TreeCmd, TreeNavCmd,
 };
-pub use self::doc::{Clipboard, Doc};
+pub use self::doc::{Clipboard, Doc, DocError};
 pub use self::notationset::NotationSet;
 pub use test_util::make_json_lang;

--- a/editor/src/notationset.rs
+++ b/editor/src/notationset.rs
@@ -13,8 +13,8 @@ lazy_static! {
     /// Notations for built-in constructs that can appear in any document.
     pub static ref BUILTIN_NOTATIONS: HashMap<ConstructName, Notation> =
         vec![
-            ("hole".to_string(), literal("?", Style::plain())),
-            ("root".to_string(), child(0)),
+            ("hole".into(), literal("?", Style::plain())),
+            ("root".into(), child(0)),
         ].into_iter().collect();
 }
 
@@ -73,12 +73,12 @@ mod example {
     pub fn example_language() -> (Language, NotationSet) {
         let mut language = Language::new("TestLang");
 
-        let arity = Arity::Fixed(vec!["Expr".to_string(), "Expr".to_string()]);
+        let arity = Arity::Fixed(vec!["Expr".into(), "Expr".into()]);
         let construct = Construct::new("plus", "Expr", arity, Some('p'));
         language.add(construct);
         let plus_notation = child(0) + punct(" + ") + child(1) | child(0) ^ punct("+ ") + child(1);
 
-        let notation = NotationSet::new(&language, vec![("plus".to_string(), plus_notation)]);
+        let notation = NotationSet::new(&language, vec![("plus".into(), plus_notation)]);
         (language, notation)
         /*
         let syn = repeat(Repeat{

--- a/editor/src/test_util/json_lang.rs
+++ b/editor/src/test_util/json_lang.rs
@@ -20,23 +20,13 @@ pub fn make_json_lang() -> (Language, NotationSet) {
         Construct::new("true", "Value", Arity::Fixed(Vec::new()), Some('t')),
         Construct::new("false", "Value", Arity::Fixed(Vec::new()), Some('f')),
         Construct::new("null", "Value", Arity::Fixed(Vec::new()), Some('x')),
-        Construct::new(
-            "list",
-            "Value",
-            Arity::Flexible("Value".to_string()),
-            Some('l'),
-        ),
-        Construct::new(
-            "dict",
-            "Value",
-            Arity::Flexible("Entry".to_string()),
-            Some('d'),
-        ),
+        Construct::new("list", "Value", Arity::Flexible("Value".into()), Some('l')),
+        Construct::new("dict", "Value", Arity::Flexible("Entry".into()), Some('d')),
         Construct::new("key", "Key", Arity::Text, Some('k')),
         Construct::new(
             "entry",
             "Entry",
-            Arity::Fixed(vec!["Key".to_string(), "Value".to_string()]),
+            Arity::Fixed(vec!["Key".into(), "Value".into()]),
             Some('e'),
         ),
     ];

--- a/language/src/construct.rs
+++ b/language/src/construct.rs
@@ -119,7 +119,7 @@ impl Arity {
         }
     }
 
-    /// Get the `Sort` of any child of this flexible or mixed node.
+    /// Get the `Sort` of all children of this flexible or mixed node.
     ///
     /// # Panics
     ///

--- a/language/src/construct.rs
+++ b/language/src/construct.rs
@@ -6,7 +6,28 @@ use std::collections::HashMap;
 use std::fmt;
 
 pub type ConstructName = String;
-pub type Sort = String; // "Any" is special
+
+#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct Sort(String); // "Any" is special
+
+impl Sort {
+    /// Construct a new "Any" sort.
+    pub fn any() -> Sort {
+        "Any".into()
+    }
+}
+
+impl From<String> for Sort {
+    fn from(s: String) -> Sort {
+        Sort(s)
+    }
+}
+
+impl<'a> From<&'a str> for Sort {
+    fn from(s: &'a str) -> Sort {
+        Sort(s.to_owned())
+    }
+}
 
 /// A syntactic construct.
 #[derive(Debug, PartialEq, Eq)]
@@ -18,10 +39,13 @@ pub struct Construct {
 }
 
 impl Construct {
-    pub fn new(name: &str, sort: &str, arity: Arity, key: Option<char>) -> Construct {
+    pub fn new<T>(name: &str, sort: T, arity: Arity, key: Option<char>) -> Construct
+    where
+        T: Into<Sort>,
+    {
         Construct {
             name: name.to_string(),
-            sort: sort.to_string(),
+            sort: sort.into(),
             arity: arity,
             key: key,
         }
@@ -85,11 +109,11 @@ lazy_static! {
     pub static ref BUILTIN_CONSTRUCTS: HashMap<ConstructName, Construct> = vec![
         (
             "hole".to_owned(),
-            Construct::new("hole", "Any", Arity::Fixed(vec!()), Some('?'))
+            Construct::new("hole", Sort::any(), Arity::Fixed(vec!()), Some('?'))
         ),
         (
             "root".to_owned(),
-            Construct::new("root", "root", Arity::Fixed(vec!["Any".into()]), None)
+            Construct::new("root", "root", Arity::Fixed(vec![Sort::any()]), None)
         )
     ].into_iter().collect();
 }

--- a/language/src/construct.rs
+++ b/language/src/construct.rs
@@ -15,6 +15,11 @@ impl Sort {
     pub fn any() -> Sort {
         "Any".into()
     }
+
+    /// Return true if a hole with this sort can accept a child with the given sort.
+    pub fn accepts(&self, child: &Sort) -> bool {
+        &self.0 == "Any" || &child.0 == "Any" || self == child
+    }
 }
 
 impl From<String> for Sort {
@@ -94,6 +99,35 @@ impl Arity {
         match self {
             Arity::Flexible(_) => true,
             _ => false,
+        }
+    }
+
+    /// Get the `Sort` of the `i`th child. For flexible-arity and mixed-arity nodes, get the `Sort`
+    /// required of all tree children, ignoring `i`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if nodes of this arity cannot have an `i`th child.
+    pub fn child_sort(&self, i: usize) -> &Sort {
+        match self {
+            Arity::Flexible(sort) | Arity::Mixed(sort) => sort, // all tree children have the same Sort
+            Arity::Fixed(sorts) => sorts.get(i).expect(&format!(
+                "child_sort - fixed node has only {} children",
+                sorts.len()
+            )),
+            _ => panic!("child_sort - node has no children"),
+        }
+    }
+
+    /// Get the `Sort` of any child of this flexible or mixed node.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the arity is not flexible or mixed.
+    pub fn uniform_child_sort(&self) -> &Sort {
+        match self {
+            Arity::Flexible(sort) | Arity::Mixed(sort) => sort, // all tree children have the same Sort
+            _ => panic!("uniform_child_sort - node is not flexible or mixed"),
         }
     }
 }


### PR DESCRIPTION
Check Sort when inserting or pasting a node, and handle the error well if the node isn't allowed there.