### PR TITLE
Only insert holes

### DIFF
--- a/demo/src/keymap.rs
+++ b/demo/src/keymap.rs
@@ -111,26 +111,6 @@ impl<'l> KmapFactory<'l> {
             (Key::Char('y'), KmapFilter::Always, Prog::single(Word::Copy)),
             (
                 Key::Char('p'),
-                KmapFilter::ParentArity(vec![ArityType::Flexible, ArityType::Mixed]),
-                Prog::single(Word::PasteAfter),
-            ),
-            (
-                Key::Char('P'),
-                KmapFilter::ParentArity(vec![ArityType::Flexible, ArityType::Mixed]),
-                Prog::single(Word::PasteBefore),
-            ),
-            (
-                Key::Ctrl('p'),
-                KmapFilter::SelfArity(vec![ArityType::Flexible, ArityType::Mixed]),
-                Prog::single(Word::PastePrepend),
-            ),
-            (
-                Key::Alt('p'),
-                KmapFilter::SelfArity(vec![ArityType::Flexible, ArityType::Mixed]),
-                Prog::single(Word::PastePostpend),
-            ),
-            (
-                Key::Char('R'),
                 KmapFilter::Always,
                 Prog::single(Word::PasteReplace),
             ),
@@ -157,54 +137,22 @@ impl<'l> KmapFactory<'l> {
             (
                 Key::Char('i'),
                 KmapFilter::ParentArity(vec![ArityType::Flexible, ArityType::Mixed]),
-                Prog::named(
-                    "InsertAfter",
-                    &[
-                        Word::InsertAfter.quote(),
-                        Word::MapName("node".into()),
-                        Word::SiblingSort,
-                        Word::PushMap,
-                    ],
-                ),
+                Prog::single(Word::InsertHoleAfter),
             ),
             (
                 Key::Char('I'),
                 KmapFilter::ParentArity(vec![ArityType::Flexible, ArityType::Mixed]),
-                Prog::named(
-                    "InsertBefore",
-                    &[
-                        Word::InsertBefore.quote(),
-                        Word::MapName("node".into()),
-                        Word::SiblingSort,
-                        Word::PushMap,
-                    ],
-                ),
+                Prog::single(Word::InsertHoleBefore),
             ),
             (
                 Key::Char('o'),
                 KmapFilter::SelfArity(vec![ArityType::Flexible, ArityType::Mixed]),
-                Prog::named(
-                    "InsertPostpend",
-                    &[
-                        Word::InsertPostpend.quote(),
-                        Word::MapName("node".into()),
-                        Word::ChildSort,
-                        Word::PushMap,
-                    ],
-                ),
+                Prog::single(Word::InsertHolePostpend),
             ),
             (
                 Key::Char('O'),
                 KmapFilter::SelfArity(vec![ArityType::Flexible, ArityType::Mixed]),
-                Prog::named(
-                    "InsertPrepend",
-                    &[
-                        Word::InsertPrepend.quote(),
-                        Word::MapName("node".into()),
-                        Word::ChildSort,
-                        Word::PushMap,
-                    ],
-                ),
+                Prog::single(Word::InsertHolePrepend),
             ),
             (
                 Key::Char('r'),
@@ -244,8 +192,9 @@ impl<'l> KmapFactory<'l> {
                     "True",
                     &[
                         Word::LangConstruct(lang.clone(), "true".into()),
+                        Word::InsertHoleAfter,
                         Word::NodeByName,
-                        Word::InsertAfter,
+                        Word::Replace,
                     ],
                 ),
             ),
@@ -256,8 +205,9 @@ impl<'l> KmapFactory<'l> {
                     "False",
                     &[
                         Word::LangConstruct(lang, "false".into()),
+                        Word::InsertHoleAfter,
                         Word::NodeByName,
-                        Word::InsertAfter,
+                        Word::Replace,
                     ],
                 ),
             ),

--- a/demo/src/main.rs
+++ b/demo/src/main.rs
@@ -385,21 +385,17 @@ impl Ed {
                 let ch = self.stack.pop_char()?;
                 self.exec(TextCmd::InsertChar(ch))?;
             }
-            Word::InsertAfter => {
-                let tree = self.stack.pop_tree()?;
-                self.exec(TreeCmd::InsertAfter(tree))?;
+            Word::InsertHoleAfter => {
+                self.exec(TreeCmd::InsertHoleAfter)?;
             }
-            Word::InsertBefore => {
-                let tree = self.stack.pop_tree()?;
-                self.exec(TreeCmd::InsertBefore(tree))?;
+            Word::InsertHoleBefore => {
+                self.exec(TreeCmd::InsertHoleBefore)?;
             }
-            Word::InsertPrepend => {
-                let tree = self.stack.pop_tree()?;
-                self.exec(TreeCmd::InsertPrepend(tree))?;
+            Word::InsertHolePrepend => {
+                self.exec(TreeCmd::InsertHolePrepend)?;
             }
-            Word::InsertPostpend => {
-                let tree = self.stack.pop_tree()?;
-                self.exec(TreeCmd::InsertPostpend(tree))?;
+            Word::InsertHolePostpend => {
+                self.exec(TreeCmd::InsertHolePostpend)?;
             }
             Word::Replace => {
                 let tree = self.stack.pop_tree()?;
@@ -416,10 +412,6 @@ impl Ed {
             Word::Redo => self.exec(CommandGroup::Redo)?,
             Word::Cut => self.exec(EditorCmd::Cut)?,
             Word::Copy => self.exec(EditorCmd::Copy)?,
-            Word::PasteAfter => self.exec(EditorCmd::PasteAfter)?,
-            Word::PasteBefore => self.exec(EditorCmd::PasteBefore)?,
-            Word::PastePrepend => self.exec(EditorCmd::PastePrepend)?,
-            Word::PastePostpend => self.exec(EditorCmd::PastePostpend)?,
             Word::PasteReplace => self.exec(EditorCmd::PasteReplace)?,
         })
     }

--- a/demo/src/prog.rs
+++ b/demo/src/prog.rs
@@ -48,10 +48,10 @@ pub enum Word<'l> {
 
     // tree/text commands:
     InsertChar,
-    InsertAfter,
-    InsertBefore,
-    InsertPrepend,
-    InsertPostpend,
+    InsertHoleAfter,
+    InsertHoleBefore,
+    InsertHolePrepend,
+    InsertHolePostpend,
     Replace,
     Remove,
     Left,
@@ -61,10 +61,6 @@ pub enum Word<'l> {
     Cut,
     Copy,
     PasteReplace,
-    PasteBefore,
-    PasteAfter,
-    PastePrepend,
-    PastePostpend,
     Undo,
     Redo,
 }

--- a/editor/src/ast/ast.rs
+++ b/editor/src/ast/ast.rs
@@ -1,5 +1,6 @@
 use std::fmt;
 
+use crate::notationset::NotationSet;
 use crate::text::Text;
 use forest::{Bookmark, Tree};
 use language::{Arity, Construct, Language};
@@ -95,9 +96,20 @@ impl<'l> Ast<'l> {
         &self.tree.data().notation
     }
 
-    /// Replace this node's `i`th child. Return the replaced child. If `tree`
-    /// cannot be inserted because it has the wrong Sort, return it as
-    /// `Err(tree)`.
+    /// Create a new `hole` node that belongs to the same forest as this node.
+    pub fn new_hole(&mut self) -> Ast<'l> {
+        let node = Node {
+            bounds: Bounds::empty(),
+            language: self.get_language(),
+            construct: Construct::hole(),
+            notation: NotationSet::hole(),
+        };
+        Ast::new(self.tree.forest_mut().new_branch(node, vec![]))
+    }
+
+    /// Replace this node's `i`th child with the `tree`. Return the replaced
+    /// child if successful. If `tree` cannot be placed here because it has the wrong
+    /// Sort, return it as `Err(tree)`.
     ///
     /// # Panics
     ///

--- a/editor/src/command.rs
+++ b/editor/src/command.rs
@@ -27,28 +27,20 @@ pub enum EditorCmd {
     Copy,
     /// Paste over the current node, replacing it.
     PasteReplace,
-    /// In a flexible sequence, paste to the left of the current node.
-    PasteBefore,
-    /// In a flexible sequence, paste to the right of the current node.
-    PasteAfter,
-    /// In a flexible parent, paste at the beginning of its children.
-    PastePrepend,
-    /// In a flexible parent, paste at the end of its children.
-    PastePostpend,
 }
 
 #[derive(Debug)]
 pub enum TreeCmd<'l> {
-    /// Replace the current node.
+    /// Replace the current node with the given node.
     Replace(Ast<'l>),
-    /// In a flexible sequence, insert to the left of the current node.
-    InsertBefore(Ast<'l>),
-    /// In a flexible sequence, insert to the right of the current node.
-    InsertAfter(Ast<'l>),
-    /// In a flexible parent, insert at the beginning of its children.
-    InsertPrepend(Ast<'l>),
-    /// In a flexible parent, insert at the end of its children.
-    InsertPostpend(Ast<'l>),
+    /// In a flexible sequence, insert a hole to the left of the current node.
+    InsertHoleBefore,
+    /// In a flexible sequence, insert a hole to the right of the current node.
+    InsertHoleAfter,
+    /// On a flexible parent, insert a hole at the beginning of its children.
+    InsertHolePrepend,
+    /// On a flexible parent, insert a hole at the end of its children.
+    InsertHolePostpend,
     /// In a flexible sequence, remove the current node.
     Remove,
 }

--- a/editor/src/doc.rs
+++ b/editor/src/doc.rs
@@ -266,7 +266,10 @@ impl<'l> Doc<'l> {
                         clipboard.push(rejected_tree);
                         DocError::CannotPaste
                     } else {
-                        err // Unexpected error, forward it along
+                        panic!(
+                            "Failed to paste, may have lost node from clipboard: {:?}",
+                            err
+                        );
                     }
                 })?;
 

--- a/editor/src/notationset.rs
+++ b/editor/src/notationset.rs
@@ -31,6 +31,12 @@ impl NotationSet {
         }
     }
 
+    pub fn hole() -> &'static Notation {
+        BUILTIN_NOTATIONS
+            .get("hole")
+            .expect("no builtin 'hole' notation found")
+    }
+
     pub fn lookup(&self, construct: &ConstructName) -> &Notation {
         match self.notations.get(construct) {
             None => match BUILTIN_NOTATIONS.get(construct) {

--- a/editor/tests/test_json_doc.rs
+++ b/editor/tests/test_json_doc.rs
@@ -62,7 +62,8 @@ fn test_json_undo_redo() {
                 lang.lookup_construct("list"),
                 &note_set,
             ))),
-            Command::Tree(TreeCmd::InsertPrepend(forest.new_fixed_tree(
+            Command::Tree(TreeCmd::InsertHolePrepend),
+            Command::Tree(TreeCmd::Replace(forest.new_fixed_tree(
                 &lang,
                 lang.lookup_construct("true"),
                 &note_set,
@@ -73,18 +74,28 @@ fn test_json_undo_redo() {
     .unwrap();
 
     doc.execute(
-        CommandGroup::Group(vec![Command::Tree(TreeCmd::InsertAfter(
-            forest.new_fixed_tree(&lang, lang.lookup_construct("null"), &note_set),
-        ))]),
+        CommandGroup::Group(vec![
+            Command::Tree(TreeCmd::InsertHoleAfter),
+            Command::Tree(TreeCmd::Replace(forest.new_fixed_tree(
+                &lang,
+                lang.lookup_construct("null"),
+                &note_set,
+            ))),
+        ]),
         &mut clipboard,
     )
     .unwrap();
     assert_render(&doc, "[true, null]");
 
     doc.execute(
-        CommandGroup::Group(vec![Command::Tree(TreeCmd::InsertBefore(
-            forest.new_fixed_tree(&lang, lang.lookup_construct("false"), &note_set),
-        ))]),
+        CommandGroup::Group(vec![
+            Command::Tree(TreeCmd::InsertHoleBefore),
+            Command::Tree(TreeCmd::Replace(forest.new_fixed_tree(
+                &lang,
+                lang.lookup_construct("false"),
+                &note_set,
+            ))),
+        ]),
         &mut clipboard,
     )
     .unwrap();
@@ -112,10 +123,14 @@ fn test_json_undo_redo() {
     assert_render(&doc, "[true, null]");
 
     doc.execute(
-        CommandGroup::Group(vec![Command::Tree(TreeCmd::InsertAfter(
-            // forest.new_fixed_tree(&lang, lang.lookup_construct("false"), &note_set),
-            forest.new_flexible_tree(&lang, lang.lookup_construct("list"), &note_set),
-        ))]),
+        CommandGroup::Group(vec![
+            Command::Tree(TreeCmd::InsertHoleAfter),
+            Command::Tree(TreeCmd::Replace(forest.new_flexible_tree(
+                &lang,
+                lang.lookup_construct("list"),
+                &note_set,
+            ))),
+        ]),
         &mut clipboard,
     )
     .unwrap();
@@ -170,17 +185,20 @@ fn test_json_cursor_at_top() {
                 lang.lookup_construct("list"),
                 &note_set,
             ))),
-            Command::Tree(TreeCmd::InsertPrepend(forest.new_fixed_tree(
+            Command::Tree(TreeCmd::InsertHolePrepend),
+            Command::Tree(TreeCmd::Replace(forest.new_fixed_tree(
                 &lang,
                 lang.lookup_construct("true"),
                 &note_set,
             ))),
-            Command::Tree(TreeCmd::InsertAfter(forest.new_fixed_tree(
+            Command::Tree(TreeCmd::InsertHoleAfter),
+            Command::Tree(TreeCmd::Replace(forest.new_fixed_tree(
                 &lang,
                 lang.lookup_construct("false"),
                 &note_set,
             ))),
-            Command::Tree(TreeCmd::InsertAfter(forest.new_fixed_tree(
+            Command::Tree(TreeCmd::InsertHoleAfter),
+            Command::Tree(TreeCmd::Replace(forest.new_fixed_tree(
                 &lang,
                 lang.lookup_construct("null"),
                 &note_set,
@@ -264,9 +282,14 @@ fn test_json_string() {
     .unwrap();
 
     doc.execute(
-        CommandGroup::Group(vec![Command::Tree(TreeCmd::InsertPrepend(
-            forest.new_text_tree(&lang, lang.lookup_construct("string"), &note_set),
-        ))]),
+        CommandGroup::Group(vec![
+            Command::Tree(TreeCmd::InsertHolePrepend),
+            Command::Tree(TreeCmd::Replace(forest.new_text_tree(
+                &lang,
+                lang.lookup_construct("string"),
+                &note_set,
+            ))),
+        ]),
         &mut clipboard,
     )
     .unwrap();

--- a/forest/src/tree.rs
+++ b/forest/src/tree.rs
@@ -311,6 +311,11 @@ impl<D, L> Tree<D, L> {
         self.id = id;
     }
 
+    /// Obtain a mutable reference to the [Forest] this tree belongs to.
+    pub fn forest_mut(&mut self) -> &mut Forest<D, L> {
+        &mut self.forest
+    }
+
     // Private //
 
     pub(super) fn new(forest: &Forest<D, L>, id: Id) -> Tree<D, L> {

--- a/language/src/construct.rs
+++ b/language/src/construct.rs
@@ -55,6 +55,12 @@ impl Construct {
             key: key,
         }
     }
+
+    pub fn hole() -> &'static Construct {
+        BUILTIN_CONSTRUCTS
+            .get("hole")
+            .expect("no builtin 'hole' construct found")
+    }
 }
 
 /// The sorts of children that a node is allowed to contain.


### PR DESCRIPTION
Instead of having 4 types of paste and 4 types of inserting a specific node type, just have 4 ways to insert holes. Then have 1 paste and 1 replace command.