### PR TITLE
Expand use of DocPosSpec

### DIFF
--- a/demo/src/main.rs
+++ b/demo/src/main.rs
@@ -222,22 +222,24 @@ impl Ed {
         let messages = self.message_doc.ast_ref();
         self.term.draw_frame(|mut pane: Pane<Terminal>| {
             pane.render(&notation, |label: &DocLabel| match label {
-                DocLabel::ActiveDoc => {
-                    Some((doc.clone(), CursorVis::Show, DocPosSpec::CursorAtTop))
-                }
+                DocLabel::ActiveDoc => Some((
+                    doc.clone(),
+                    CursorVis::Show,
+                    DocPosSpec::CursorHeight { fraction: 0.6 },
+                )),
                 DocLabel::ActiveDocName => {
-                    Some((doc_name.clone(), CursorVis::Hide, DocPosSpec::CursorAtTop))
+                    Some((doc_name.clone(), CursorVis::Hide, DocPosSpec::Beginning))
                 }
                 DocLabel::KeymapName => Some((
                     key_hints_name.clone(),
                     CursorVis::Hide,
-                    DocPosSpec::CursorAtTop,
+                    DocPosSpec::Beginning,
                 )),
                 DocLabel::KeyHints => {
-                    Some((key_hints.clone(), CursorVis::Hide, DocPosSpec::CursorAtTop))
+                    Some((key_hints.clone(), CursorVis::Hide, DocPosSpec::Beginning))
                 }
                 DocLabel::Messages => {
-                    Some((messages.clone(), CursorVis::Hide, DocPosSpec::CursorAtTop))
+                    Some((messages.clone(), CursorVis::Hide, DocPosSpec::Beginning))
                 }
                 _ => None,
             })?;

--- a/demo/src/main.rs
+++ b/demo/src/main.rs
@@ -11,7 +11,9 @@ use editor::{
 use forest::Bookmark;
 use frontends::{Event, Frontend, Terminal};
 use language::{LanguageName, LanguageSet, Sort};
-use pretty::{Color, ColorTheme, CursorVis, DocLabel, Pane, PaneNotation, PaneSize, Style};
+use pretty::{
+    Color, ColorTheme, CursorVis, DocLabel, DocPosSpec, Pane, PaneNotation, PaneSize, Style,
+};
 use utility::GrowOnlyMap;
 
 mod demo_keymaps;
@@ -220,11 +222,23 @@ impl Ed {
         let messages = self.message_doc.ast_ref();
         self.term.draw_frame(|mut pane: Pane<Terminal>| {
             pane.render(&notation, |label: &DocLabel| match label {
-                DocLabel::ActiveDoc => Some((doc.clone(), CursorVis::Show)),
-                DocLabel::ActiveDocName => Some((doc_name.clone(), CursorVis::Hide)),
-                DocLabel::KeymapName => Some((key_hints_name.clone(), CursorVis::Hide)),
-                DocLabel::KeyHints => Some((key_hints.clone(), CursorVis::Hide)),
-                DocLabel::Messages => Some((messages.clone(), CursorVis::Hide)),
+                DocLabel::ActiveDoc => {
+                    Some((doc.clone(), CursorVis::Show, DocPosSpec::CursorAtTop))
+                }
+                DocLabel::ActiveDocName => {
+                    Some((doc_name.clone(), CursorVis::Hide, DocPosSpec::CursorAtTop))
+                }
+                DocLabel::KeymapName => Some((
+                    key_hints_name.clone(),
+                    CursorVis::Hide,
+                    DocPosSpec::CursorAtTop,
+                )),
+                DocLabel::KeyHints => {
+                    Some((key_hints.clone(), CursorVis::Hide, DocPosSpec::CursorAtTop))
+                }
+                DocLabel::Messages => {
+                    Some((messages.clone(), CursorVis::Hide, DocPosSpec::CursorAtTop))
+                }
                 _ => None,
             })?;
             Ok(())

--- a/editor/tests/test_json_doc.rs
+++ b/editor/tests/test_json_doc.rs
@@ -142,16 +142,28 @@ fn test_json_cursor_at_top() {
         DocPosSpec::Fixed(Pos::zero()),
     );
 
-    ed.assert_render_with(" null]", width, DocPosSpec::CursorAtTop);
+    ed.assert_render_with(" null]", width, DocPosSpec::CursorHeight { fraction: 1.0 });
 
     ed.exec(TreeNavCmd::Left).unwrap();
-    ed.assert_render_with(" false,\n null]", width, DocPosSpec::CursorAtTop);
+    ed.assert_render_with(
+        " false,\n null]",
+        width,
+        DocPosSpec::CursorHeight { fraction: 1.0 },
+    );
 
     ed.exec(TreeNavCmd::Left).unwrap();
-    ed.assert_render_with("[true,\n false,\n null]", width, DocPosSpec::CursorAtTop);
+    ed.assert_render_with(
+        "[true,\n false,\n null]",
+        width,
+        DocPosSpec::CursorHeight { fraction: 1.0 },
+    );
 
     ed.exec(TreeNavCmd::Parent).unwrap();
-    ed.assert_render_with("[true,\n false,\n null]", width, DocPosSpec::CursorAtTop);
+    ed.assert_render_with(
+        "[true,\n false,\n null]",
+        width,
+        DocPosSpec::CursorHeight { fraction: 1.0 },
+    );
 }
 
 #[test]

--- a/pretty/src/pane.rs
+++ b/pretty/src/pane.rs
@@ -161,7 +161,7 @@ where
         get_content: F,
     ) -> Result<(), PaneError<T::Error>>
     where
-        F: Fn(&DocLabel) -> Option<(U, CursorVis)>,
+        F: Fn(&DocLabel) -> Option<(U, CursorVis, DocPosSpec)>,
         F: Clone,
         U: PrettyDocument,
     {
@@ -198,7 +198,7 @@ where
                             // Convert dynamic height into a fixed height, based on the currrent document.
                             if let PaneNotation::Doc { label, .. } = &p.1 {
                                 let f = get_content.clone();
-                                let (doc, _) =
+                                let (doc, _, _) =
                                     f(label).ok_or(PaneError::Missing(label.to_owned()))?;
                                 let height =
                                     available_height.min(doc.required_height(self.rect().width()));
@@ -227,10 +227,9 @@ where
             }
             PaneNotation::Doc { label } => {
                 let width = self.rect().width();
-
-                let (doc, cursor_visibility) =
+                let (doc, cursor_visibility, doc_pos_spec) =
                     get_content(label).ok_or(PaneError::Missing(label.to_owned()))?;
-                doc.pretty_print(width, self, DocPosSpec::CursorAtTop, cursor_visibility)?;
+                doc.pretty_print(width, self, doc_pos_spec, cursor_visibility)?;
             }
             PaneNotation::Fill { ch, style } => {
                 let line: String = iter::repeat(ch)

--- a/pretty/src/pane.rs
+++ b/pretty/src/pane.rs
@@ -129,6 +129,8 @@ where
     /// given relative position (where 0,0 is the top left corner of the
     /// `Pane`). No newlines allowed.
     pub fn print(&mut self, pos: Pos, text: &str, style: Style) -> Result<(), T::Error> {
+        // TODO check if this fits in the pane. Currently, `fit_bound()` panics
+        // if it doesn't fit in the pane, so there's not much point in checking yet.
         let abs_pos = pos + self.rect.pos();
         self.window.print(abs_pos, text, style)
     }
@@ -141,8 +143,12 @@ where
         shade: Option<Shade>,
         reverse: bool,
     ) -> Result<(), T::Error> {
-        let abs_region = region + self.rect.pos();
-        self.window.highlight(abs_region, shade, reverse)
+        if let Some(abs_region) = (region + self.rect.pos()).crop(self.rect) {
+            self.window.highlight(abs_region, shade, reverse)
+        } else {
+            // None of the region is visible in this pane, do nothing.
+            Ok(())
+        }
     }
 
     /// Render to this pane according to the given [PaneNotation], `note`. Use
@@ -346,5 +352,4 @@ mod tests {
             vec!(4455, 7937, 4454, 567, 972, 16198)
         );
     }
-
 }

--- a/pretty/tests/test_json_notation.rs
+++ b/pretty/tests/test_json_notation.rs
@@ -279,7 +279,7 @@ fn test_pane_content() {
     };
     let mut pane = window.pane().unwrap();
     pane.render(&pane_note, |_: &DocLabel| {
-        Some((doc.as_ref(), CursorVis::Hide))
+        Some((doc.as_ref(), CursorVis::Hide, DocPosSpec::CursorAtTop))
     })
     .unwrap();
     assert_strings_eq(&window.to_string(), "true");
@@ -309,8 +309,8 @@ fn test_pane_horz() {
 
     let mut pane = window.pane().unwrap();
     pane.render(&pane_note, |label: &DocLabel| match label {
-        DocLabel::ActiveDoc => Some((doc1.as_ref(), CursorVis::Hide)),
-        DocLabel::KeyHints => Some((doc2.as_ref(), CursorVis::Hide)),
+        DocLabel::ActiveDoc => Some((doc1.as_ref(), CursorVis::Hide, DocPosSpec::CursorAtTop)),
+        DocLabel::KeyHints => Some((doc2.as_ref(), CursorVis::Hide, DocPosSpec::CursorAtTop)),
         _ => None,
     })
     .unwrap();
@@ -355,8 +355,8 @@ fn test_pane_vert() {
 
     let mut pane = window.pane().unwrap();
     pane.render(&pane_note, |label: &DocLabel| match label {
-        DocLabel::ActiveDoc => Some((doc1.as_ref(), CursorVis::Hide)),
-        DocLabel::KeyHints => Some((doc2.as_ref(), CursorVis::Hide)),
+        DocLabel::ActiveDoc => Some((doc1.as_ref(), CursorVis::Hide, DocPosSpec::CursorAtTop)),
+        DocLabel::KeyHints => Some((doc2.as_ref(), CursorVis::Hide, DocPosSpec::CursorAtTop)),
         _ => None,
     })
     .unwrap();
@@ -385,7 +385,7 @@ fn test_pane_fill() {
 
     let mut pane = window.pane().unwrap();
     pane.render(&pane_note, |_label: &DocLabel| {
-        Some((doc1.as_ref(), CursorVis::Hide))
+        Some((doc1.as_ref(), CursorVis::Hide, DocPosSpec::CursorAtTop))
     })
     .unwrap();
     assert_strings_eq(&window.to_string(), "true\n------\n------");
@@ -421,7 +421,7 @@ fn assert_proportional(expected: &str, width: Col, hungers: (usize, usize, usize
     let mut window = PlainText::new(Pos { row: 1, col: width });
     let mut pane = window.pane().unwrap();
     pane.render(&pane_note, |_label: &DocLabel| {
-        Some((doc1.as_ref(), CursorVis::Hide))
+        Some((doc1.as_ref(), CursorVis::Hide, DocPosSpec::CursorAtTop))
     })
     .unwrap();
     assert_strings_eq(&window.to_string(), expected);
@@ -469,7 +469,7 @@ fn test_pane_dyn_height() {
         let mut window = PlainText::new(Pos { row: 3, col: 6 });
         let mut pane = window.pane().unwrap();
         pane.render(&pane_note, |_label: &DocLabel| {
-            Some((doc.as_ref(), CursorVis::Hide))
+            Some((doc.as_ref(), CursorVis::Hide, DocPosSpec::CursorAtTop))
         })
         .unwrap();
         assert_strings_eq(&window.to_string(), expected);
@@ -506,7 +506,7 @@ fn test_print_outside() {
 
     let mut pane = window.pane().unwrap();
     pane.render(&pane_note, |_label: &DocLabel| {
-        Some((doc1.as_ref(), CursorVis::Hide))
+        Some((doc1.as_ref(), CursorVis::Hide, DocPosSpec::CursorAtTop))
     })
     .unwrap();
     assert_strings_eq(&window.to_string(), "fals----");

--- a/pretty/tests/test_json_notation.rs
+++ b/pretty/tests/test_json_notation.rs
@@ -480,3 +480,34 @@ fn test_pane_dyn_height() {
     assert_render(doc2, "[true,\n true]\n------");
     assert_render(doc3, "[true,\n true,\n true]");
 }
+
+// TODO this test currently panics, but should eventually be enabled
+// #[test]
+fn test_print_outside() {
+    let notations = make_json_notation();
+
+    let doc1 = Doc::new_branch(notations["false"].clone(), Vec::new());
+    let mut window = PlainText::new(Pos { row: 1, col: 8 });
+
+    let content1 = PaneNotation::Doc {
+        label: DocLabel::ActiveDoc,
+    };
+    let content2 = PaneNotation::Fill {
+        ch: '-',
+        style: Style::plain(),
+    };
+
+    let pane_note = PaneNotation::Horz {
+        panes: vec![
+            (PaneSize::Fixed(4), content1),
+            (PaneSize::Fixed(4), content2),
+        ],
+    };
+
+    let mut pane = window.pane().unwrap();
+    pane.render(&pane_note, |_label: &DocLabel| {
+        Some((doc1.as_ref(), CursorVis::Hide))
+    })
+    .unwrap();
+    assert_strings_eq(&window.to_string(), "fals----");
+}

--- a/pretty/tests/test_json_notation.rs
+++ b/pretty/tests/test_json_notation.rs
@@ -8,6 +8,7 @@ use pretty::{
     PrettyWindow, Style,
 };
 
+// TODO: test ScrollStrategies other than Beginning.
 // TODO: test horz concat
 
 #[test]

--- a/pretty/tests/test_json_notation.rs
+++ b/pretty/tests/test_json_notation.rs
@@ -279,7 +279,7 @@ fn test_pane_content() {
     };
     let mut pane = window.pane().unwrap();
     pane.render(&pane_note, |_: &DocLabel| {
-        Some((doc.as_ref(), CursorVis::Hide, DocPosSpec::CursorAtTop))
+        Some((doc.as_ref(), CursorVis::Hide, DocPosSpec::Beginning))
     })
     .unwrap();
     assert_strings_eq(&window.to_string(), "true");
@@ -309,8 +309,8 @@ fn test_pane_horz() {
 
     let mut pane = window.pane().unwrap();
     pane.render(&pane_note, |label: &DocLabel| match label {
-        DocLabel::ActiveDoc => Some((doc1.as_ref(), CursorVis::Hide, DocPosSpec::CursorAtTop)),
-        DocLabel::KeyHints => Some((doc2.as_ref(), CursorVis::Hide, DocPosSpec::CursorAtTop)),
+        DocLabel::ActiveDoc => Some((doc1.as_ref(), CursorVis::Hide, DocPosSpec::Beginning)),
+        DocLabel::KeyHints => Some((doc2.as_ref(), CursorVis::Hide, DocPosSpec::Beginning)),
         _ => None,
     })
     .unwrap();
@@ -355,8 +355,8 @@ fn test_pane_vert() {
 
     let mut pane = window.pane().unwrap();
     pane.render(&pane_note, |label: &DocLabel| match label {
-        DocLabel::ActiveDoc => Some((doc1.as_ref(), CursorVis::Hide, DocPosSpec::CursorAtTop)),
-        DocLabel::KeyHints => Some((doc2.as_ref(), CursorVis::Hide, DocPosSpec::CursorAtTop)),
+        DocLabel::ActiveDoc => Some((doc1.as_ref(), CursorVis::Hide, DocPosSpec::Beginning)),
+        DocLabel::KeyHints => Some((doc2.as_ref(), CursorVis::Hide, DocPosSpec::Beginning)),
         _ => None,
     })
     .unwrap();
@@ -385,7 +385,7 @@ fn test_pane_fill() {
 
     let mut pane = window.pane().unwrap();
     pane.render(&pane_note, |_label: &DocLabel| {
-        Some((doc1.as_ref(), CursorVis::Hide, DocPosSpec::CursorAtTop))
+        Some((doc1.as_ref(), CursorVis::Hide, DocPosSpec::Beginning))
     })
     .unwrap();
     assert_strings_eq(&window.to_string(), "true\n------\n------");
@@ -421,7 +421,7 @@ fn assert_proportional(expected: &str, width: Col, hungers: (usize, usize, usize
     let mut window = PlainText::new(Pos { row: 1, col: width });
     let mut pane = window.pane().unwrap();
     pane.render(&pane_note, |_label: &DocLabel| {
-        Some((doc1.as_ref(), CursorVis::Hide, DocPosSpec::CursorAtTop))
+        Some((doc1.as_ref(), CursorVis::Hide, DocPosSpec::Beginning))
     })
     .unwrap();
     assert_strings_eq(&window.to_string(), expected);
@@ -469,7 +469,7 @@ fn test_pane_dyn_height() {
         let mut window = PlainText::new(Pos { row: 3, col: 6 });
         let mut pane = window.pane().unwrap();
         pane.render(&pane_note, |_label: &DocLabel| {
-            Some((doc.as_ref(), CursorVis::Hide, DocPosSpec::CursorAtTop))
+            Some((doc.as_ref(), CursorVis::Hide, DocPosSpec::Beginning))
         })
         .unwrap();
         assert_strings_eq(&window.to_string(), expected);
@@ -506,7 +506,7 @@ fn test_print_outside() {
 
     let mut pane = window.pane().unwrap();
     pane.render(&pane_note, |_label: &DocLabel| {
-        Some((doc1.as_ref(), CursorVis::Hide, DocPosSpec::CursorAtTop))
+        Some((doc1.as_ref(), CursorVis::Hide, DocPosSpec::Beginning))
     })
     .unwrap();
     assert_strings_eq(&window.to_string(), "fals----");


### PR DESCRIPTION
Add a new DocPosSpec variant, and start including in the get_content() closure.