### PR TITLE
Create Makefile and instructions for installation from source

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,11 +7,11 @@ ifneq ("$(wildcard $(shell which synless))","")
 EXISTING_BIN_PATH = $(shell which synless)
 endif
 
+SOURCES = $(wildcard src/**)
 
 # Build synless executable
-./target/debug/synless:
+./target/debug/synless: $(SOURCES)
 	cargo build
-
 
 # Install the executable to the specified INSTALL_DIR
 .PHONY: install
@@ -21,7 +21,6 @@ ifdef EXISTING_BIN_PATH
 endif
 	sudo cp $(shell pwd)/target/debug/synless $(INSTALL_DIR)
 
-
 # Uninstall the executable from EXISTING_BIN_PATH
 .PHONY: uninstall
 uninstall: $(EXISTING_BIN_PATH)
@@ -29,7 +28,6 @@ ifndef EXISTING_BIN_PATH
 	$(error ERROR: synless binary not installed in the current path)
 endif
 	sudo rm -i $(EXISTING_BIN_PATH)
-
 
 # Remove generated files
 .PHONY: clean

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,37 @@
+shell := /bin/bash
+
+INSTALL_DIR=/usr/local/bin
+
+# Check if synless is already installed in the current path
+ifneq ("$(wildcard $(shell which synless))","")
+EXISTING_BIN_PATH = $(shell which synless)
+endif
+
+
+# Build synless executable
+./target/debug/synless:
+	cargo build
+
+
+# Install the executable to the specified INSTALL_DIR
+.PHONY: install
+install: ./target/debug/synless
+ifdef EXISTING_BIN_PATH
+	$(error ERROR: Conflicting binary already installed in the current path at $(EXISTING_BIN_PATH))
+endif
+	sudo cp $(shell pwd)/target/debug/synless $(INSTALL_DIR)
+
+
+# Uninstall the executable from EXISTING_BIN_PATH
+.PHONY: uninstall
+uninstall: $(EXISTING_BIN_PATH)
+ifndef EXISTING_BIN_PATH
+	$(error ERROR: synless binary not installed in the current path)
+endif
+	sudo rm -i $(EXISTING_BIN_PATH)
+
+
+# Remove generated files
+.PHONY: clean
+clean:
+	rm -r target

--- a/readme.md
+++ b/readme.md
@@ -41,3 +41,43 @@ To learn more:
 [The Synless Design Documentation](doc/design.md) (for developers)
 
 [An Incomplete Survey of Tree Editors](doc/survey.md)
+
+## Install from source (Linux)
+
+### Prerequisites
+
+1. [Install Rust](https://www.rust-lang.org/tools/install)
+2. Clone this repository
+3. `cd` into the repository (i.e. `cd synless`)
+
+### Build and install the executable
+
+This will build and install the executable to a default installation directory:
+
+    make install
+
+You may specify the installation directory with `INSTALL_DIR`:
+
+    make install INSTALL_DIR=/path/to/bin
+
+#### Run the executable
+
+To verify your installation, run the executable from any working directory:
+
+    synless
+
+### Clean up generated files
+
+This will remove the `target` directory:
+
+    make clean
+
+### Uninstall
+
+This will remove the executable from the default installation directory:
+
+    make uninstall
+
+You may specify the installation directory with `INSTALL_DIR`:
+  
+    make uninstall INSTALL_DIR=/path/to/bin


### PR DESCRIPTION
This PR adds a Makefile and instructions to make installation from source easier.

For instructions on how to test, read the additions made to the readme file.

Admittedly, this is optimized for Ubuntu. To make this OS agnostic, we will want to set `INSTALL_PATH` based on the OS. For information on how we can do this, see [Stack Overflow: OS detecting makefile](https://stackoverflow.com/questions/714100/os-detecting-makefile).

Feel free to add commits to this branch!